### PR TITLE
Align Crud#client args with Crud.client args.

### DIFF
--- a/lib/daisybill_api/ext/crud.rb
+++ b/lib/daisybill_api/ext/crud.rb
@@ -110,8 +110,8 @@ module DaisybillApi
 
         private
 
-        def client(method, url, data)
-          self.class.client method, url, data
+        def client(method, path, params = {})
+          self.class.client method, path, params
         end
 
         def send_data(method, url)


### PR DESCRIPTION
- Aligns the argument names of the instance method
  with the class method it calls - and the 
  DaisybillApi::Data::Client it builds.
- Resolves issue where destroy operations (which 
  aren’t in use yet) will fail because 
  DaisybillApi::Ext::CRUD::Destroy#destroy expects
  to be able to omit the params hash.
