### PR TITLE
Fix associations for pharmacy bills

### DIFF
--- a/lib/daisybill_api/ext/associations.rb
+++ b/lib/daisybill_api/ext/associations.rb
@@ -16,6 +16,7 @@ module DaisybillApi
           define_method name do |params = {}|
             params.merge!(:"#{self.class.singular_key}_id" => self.id)
             params.merge!(path: "#{show_path}/#{name}") if options[:set_path]
+            params.merge!(path: clazz.constantize.index_path(id)) if options[:set_path] && options[:use_path_prefix]
             params.merge!(collection_key: options[:collection_key]) if options[:collection_key]
             clazz.constantize.all(params)
           end

--- a/lib/daisybill_api/models/pharmacy_bill.rb
+++ b/lib/daisybill_api/models/pharmacy_bill.rb
@@ -37,9 +37,9 @@ module DaisybillApi
       link :place_of_service, class: 'PlaceOfService'
       link :prescribing_provider, class: 'PrescribingProvider'
 
-      has_many :attachments, class: 'Attachment'
-      has_many :bill_payments, class: 'BillPayment'
-      has_many :bill_submissions, class: 'BillSubmission'
+      has_many :attachments,      class: 'Attachment',     set_path: true, use_path_prefix: true
+      has_many :bill_payments,    class: 'BillPayment',    set_path: true, use_path_prefix: true
+      has_many :bill_submissions, class: 'BillSubmission', set_path: true, use_path_prefix: true
 
       def write_off
         @written_off = send_data :post, write_off_path


### PR DESCRIPTION
- use `set_path` and `use_path_prefix` to use dependent model's
`path_prefix` for index actions. This resolves an issue preventing users
from retrieving bill payments, bill submissions, and attachments for
pharmacy bills.