### PR TITLE
[#116] Send API Token in Authorization Header

### DIFF
--- a/lib/daisybill_api/data/url.rb
+++ b/lib/daisybill_api/data/url.rb
@@ -13,7 +13,10 @@ module DaisybillApi
               host: DaisybillApi.configuration.host,
               port: port,
               path: "#{DEFAULT_PATH}#{path}",
-              query: to_query(params.merge api_token: DaisybillApi.configuration.api_token)
+              headers: {
+                "Authorization" => "Bearer #{DaisybillApi.configuration.api_token}"
+              },
+              query: to_query(params)
             })
         end
 


### PR DESCRIPTION
- This is because daisyBill is deprecating sending the API Token in the query params of the request
- Resolves #116 